### PR TITLE
Set charset=utf-8 to Content-Type header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export function vesper(schema: any, options?: object) {
 
         }).then((gqlResponse) => {
 
-            res.setHeader("Content-Type", "application/json");
+            res.setHeader("Content-Type", "application/json; charset=utf-8");
             res.setHeader("Content-Length", String(Buffer.byteLength(gqlResponse, "utf8")));
             res.write(gqlResponse);
             res.end();


### PR DESCRIPTION
Small change to fix encoding (js-graphql-intellij-plugin has an output, as in this [issue](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/issues/123))