### PR TITLE
Fix bug when connection does not have options. Fixes #33.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,8 @@ export function vesper(schema: any, options?: object) {
             // commit transaction
             const transactionEntityManager = container.has(EntityManager) ? container.get(EntityManager) : undefined;
             if (transactionEntityManager &&
-                transactionEntityManager.connection.options.type !== "mongodb" &&
+                (!transactionEntityManager.connection.options ||
+                    transactionEntityManager.connection.options.type !== "mongodb") &&
                 transactionEntityManager.queryRunner &&
                 transactionEntityManager.queryRunner.isTransactionActive &&
                 transactionEntityManager.queryRunner.isReleased === false) {
@@ -138,7 +139,8 @@ export function vesper(schema: any, options?: object) {
             // rollback transaction
             const transactionEntityManager = container.has(EntityManager) ? container.get(EntityManager) : undefined;
             if (transactionEntityManager &&
-                transactionEntityManager.connection.options.type !== "mongodb" &&
+                (!transactionEntityManager.connection.options ||
+                    transactionEntityManager.connection.options.type !== "mongodb") &&
                 transactionEntityManager.queryRunner &&
                 transactionEntityManager.queryRunner.isTransactionActive &&
                 transactionEntityManager.queryRunner.isReleased === false) {


### PR DESCRIPTION
This is a simple fix that saves the day. The real cause as to why `connection` has options sometimes and sometimes not should also be fixed I guess.

Small demo of the bug
![vesper_bug](https://user-images.githubusercontent.com/21707/42617008-826c7df0-85b0-11e8-95a2-d3737f064261.gif)

Reproduction project: https://github.com/lucidogen/lucidogen (branch vesper, client and server are in `packages/apps`)