### PR TITLE
Added subscription path options.

### DIFF
--- a/src/VesperFramework.ts
+++ b/src/VesperFramework.ts
@@ -95,11 +95,13 @@ export class VesperFramework {
                     return fail(err);
 
                 // register the WebSocket for handling GraphQL subscriptions
+                const subscriptionsRoute = this.options.subscriptionsRoute || "/subscriptions";
+                const subscriptionsDomain = this.options.subscriptionsDomain || `localhost:${this.options.port}`;
                 const hasSubscriptions = getMetadataArgsStorage().actions.filter(action => action.type === "subscription");
                 if (hasSubscriptions) {
                     new SubscriptionServer(
                         { execute: execute as any, subscribe, schema },
-                        { server: this.server, path: "/subscriptions" }
+                        { server: this.server, path: subscriptionsRoute }
                     );
                 }
 
@@ -108,7 +110,7 @@ export class VesperFramework {
                     const graphIQLRoute = (this.options.graphIQLRoute && typeof this.options.graphIQLRoute === "string") ? this.options.graphIQLRoute : "/graphiql";
                     const graphIOptions: any = { endpointURL: graphQLRoute };
                     if (hasSubscriptions)
-                        graphIOptions.subscriptionsEndpoint = `ws://localhost:${this.options.port}/subscriptions`;
+                        graphIOptions.subscriptionsEndpoint = `wss://${subscriptionsDomain}${subscriptionsRoute}`;
                     this.application.use(graphIQLRoute, graphiqlExpress(graphIOptions));
                 }
 
@@ -119,7 +121,7 @@ export class VesperFramework {
                     const playgroundRoute = (this.options.playground && typeof this.options.playground === "string") ? this.options.playground : "/playground";
                     const graphIOptions: any = { endpoint: graphQLRoute };
                     if (hasSubscriptions)
-                        graphIOptions.subscriptionsEndpoint = `ws://localhost:${this.options.port}/subscriptions`;
+                        graphIOptions.subscriptionsEndpoint = `wss://${subscriptionsDomain}${subscriptionsRoute}`;
                     this.application.use(playgroundRoute, expressPlayground(graphIOptions));
                 }
 

--- a/src/options/VesperFrameworkOptions.ts
+++ b/src/options/VesperFrameworkOptions.ts
@@ -40,6 +40,18 @@ export interface VesperFrameworkOptions extends SchemaBuilderOptions {
     graphIQLRoute?: string|boolean;
 
     /**
+     * Route used for subscriptions.
+     * By default is equal to "/subscriptions".
+     */
+    subscriptionsRoute?: string;
+
+    /**
+     * Domain used for GraphiQL/playground subscriptions.
+     * By default is equal to "localhost:<port>".
+     */
+    subscriptionsDomain?: string;
+
+    /**
      * Route used for GraphQL playground.
      * This is an alternative to GraphiQL.
      * By default route equal to "/playground".


### PR DESCRIPTION
This change allows me to set the subscriptions path so I can get my API working in Azure. If the added options are not set it will default to what it was hard-coded to before, so it will behave exactly the same unless the new options are used.

The added options are:
subscriptionsRoute (defaults to '/subscriptions')
subscriptionsDomain (defaults to `localhost:${this.options.port}`)